### PR TITLE
move "ExtensionFunctions" out of "config"

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -24,10 +24,10 @@
 		"PluggableSSO\\Hooks": "PluggableSSO.hooks.php",
 		"PluggableSSO\\Auth":  "PluggableSSOAuth.php"
 	},
+	"ExtensionFunctions": [
+		"PluggableSSO\\Hooks::initExtension"
+	],
 	"config": {
-		"ExtensionFunctions": [
-			"PluggableSSO\\Hooks::initExtension"
-		],
 		"SSOHeader": "REMOTE_USER",
 		"AuthRemoteuserDomain": "example.wiki"
 	},


### PR DESCRIPTION
Hi Mark, 

this is the first of two pull requests: when "ExtensionFunctions" is inside "config" it **replaces** the list of registered ExtensionFunctions. So I had to move it to the top-level to make it well-behaved.